### PR TITLE
Remove duplicate Font Awesome import and centralize social links

### DIFF
--- a/assets/data/social-links.json
+++ b/assets/data/social-links.json
@@ -1,0 +1,12 @@
+{
+  "cv": {"label": "CV", "href": "cv.pdf", "icon": "far fa-file-pdf"},
+  "linkedin": {"label": "LinkedIn", "href": "https://www.linkedin.com/in/AlexSigaras", "icon": "fab fa-linkedin-in"},
+  "x": {"label": "X", "href": "https://twitter.com/AlexSigaras", "icon": "fab fa-twitter-x"},
+  "google_scholar": {"label": "Google Scholar", "href": "https://scholar.google.com/citations?user=LupDxKUAAAAJ&hl=en&oi=ao", "icon": "ai ai-google-scholar"},
+  "orcid": {"label": "ORCID", "href": "https://orcid.org/0000-0002-7607-559X", "icon": "ai ai-orcid"},
+  "pubmed": {"label": "PubMed", "href": "https://www.ncbi.nlm.nih.gov/myncbi/alexandros.sigaras.1/bibliography/public/", "icon": "ai ai-pubmed"},
+  "nih_reporter": {"label": "NIH Reporter", "href": "https://reporter.nih.gov/search/wLwxNPurzE2RuuqxhvwP9w/projects", "icon": "fa fa-list"},
+  "web_of_science": {"label": "Web of Science", "href": "https://www.webofscience.com/wos/author/record/K-3037-2015", "icon": "ai ai-clarivate"},
+  "semantic_scholar": {"label": "Semantic Scholar", "href": "https://www.semanticscholar.org/author/Alexandros-Sigaras/2835550", "icon": "ai ai-semantic-scholar"},
+  "github": {"label": "Github", "href": "https://github.com/alexsigaras", "icon": "fab fa-github"}
+}

--- a/assets/js/social-links.js
+++ b/assets/js/social-links.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', function () {
+  fetch('assets/data/social-links.json')
+    .then(function (response) { return response.json(); })
+    .then(function (links) {
+      document.querySelectorAll('[data-social-links]').forEach(function (container) {
+        var filter = (container.getAttribute('data-social-links') || '').trim();
+        var keys = filter ? filter.split(/\s+/) : Object.keys(links);
+        keys.forEach(function (key) {
+          var link = links[key];
+          if (!link) return;
+          var a = document.createElement('a');
+          a.href = link.href;
+          a.target = '_blank';
+          a.className = 'btn btn-link';
+          var i = document.createElement('i');
+          i.className = link.icon + ' i-before';
+          a.appendChild(i);
+          a.appendChild(document.createTextNode(link.label));
+          container.appendChild(a);
+        });
+      });
+    });
+});

--- a/index.html
+++ b/index.html
@@ -36,8 +36,7 @@
         integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"
         integrity="sha256-+N4/V/SbAFiW1MPBCXnfnP9QSN3+Keu+NlB+0ev/YKQ=" crossorigin="anonymous" /> -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" 
-        integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="assets/plugins/animate.css/animate.min.css" />
     <!-- <link rel="stylesheet" href="assets/plugins/slick-carousel/slick/slick.css" /> -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.css"
@@ -45,8 +44,6 @@
 
     <!-- CSS Icons -->
     <link rel="stylesheet" href="assets/css/themify-icons.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
-        integrity="sha256-+N4/V/SbAFiW1MPBCXnfnP9QSN3+Keu+NlB+0ev/YKQ=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css">
 
     <!-- CSS Base -->
@@ -99,26 +96,7 @@
                             <h2><span class="typing text-muted">Assistant Professor of Research in Systems and Computational Biomedicine</span> <a href="#about"
                                     class="btn-go btn-go-down  show-after-typing ml-4"><i
                                         class="fa fa-angle-down"></i></a></h2>
-                            <a href="cv.pdf" target="_blank" class="btn btn-link"><i
-                                    class="far fa-file-pdf i-before"></i>CV</a>
-                            <a href="https://www.linkedin.com/in/AlexSigaras" target="_blank" class="btn btn-link"><i
-                                    class="fab fa-linkedin-in i-before"></i>LinkedIn</a>
-                            <a href="https://twitter.com/AlexSigaras" target="_blank" class="btn btn-link"><i
-                                    class="fab fa-twitter-x i-before"></i>X</a>
-                            <a href="https://scholar.google.com/citations?user=LupDxKUAAAAJ&hl=en&oi=ao" target="_blank"
-                                class="btn btn-link"><i class="ai ai-google-scholar i-before"></i>Google Scholar</a>
-                            <a href="https://orcid.org/0000-0002-7607-559X" target="_blank" class="btn btn-link"><i
-                                    class="ai ai-orcid i-before"></i>ORCID</a>
-                            <a href="https://www.ncbi.nlm.nih.gov/myncbi/alexandros.sigaras.1/bibliography/public/"
-                                    target="_blank" class="btn btn-link"><i class="ai ai-pubmed i-before"></i>PubMed</a>
-                            <a href="https://reporter.nih.gov/search/wLwxNPurzE2RuuqxhvwP9w/projects"
-                                    target="_blank" class="btn btn-link"><i class="fa fa-list i-before"></i>NIH Reporter</a>
-                            <a href="https://www.webofscience.com/wos/author/record/K-3037-2015"
-                                    target="_blank" class="btn btn-link"><i class="ai ai-clarivate i-before"></i>Web of Science</a>
-                            <a href="https://www.semanticscholar.org/author/Alexandros-Sigaras/2835550"
-                                    target="_blank" class="btn btn-link"><i class="ai ai-semantic-scholar i-before"></i>Semantic Scholar</a>
-                            <a href="https://github.com/alexsigaras" target="_blank" class="btn btn-link"><i
-                                    class="fab fa-github i-before"></i>Github</a>
+                            <div data-social-links></div>
                         </div>
                     </div>
                 </div>
@@ -181,26 +159,7 @@
             <div class="container">
                 <div class="row align-items-center">
                     <div class="col-md-12 mb-5 mb-md-0 text-center text-md-left">
-                        <a href="cv.pdf" target="_blank" class="btn btn-link"><i
-                            class="far fa-file-pdf i-before"></i>CV</a>
-                        <a href="https://www.linkedin.com/in/AlexSigaras" target="_blank" class="btn btn-link"><i
-                                class="fab fa-linkedin-in i-before"></i>LinkedIn</a>
-                        <a href="https://twitter.com/AlexSigaras" target="_blank" class="btn btn-link"><i
-                                class="fab fa-twitter-x i-before"></i>X</a>
-                        <a href="https://scholar.google.com/citations?user=LupDxKUAAAAJ&hl=en&oi=ao" target="_blank"
-                            class="btn btn-link"><i class="ai ai-google-scholar i-before"></i>Google Scholar</a>
-                        <a href="https://orcid.org/0000-0002-7607-559X" target="_blank" class="btn btn-link"><i
-                                class="ai ai-orcid i-before"></i>ORCID</a>
-                        <a href="https://www.ncbi.nlm.nih.gov/myncbi/alexandros.sigaras.1/bibliography/public/"
-                                target="_blank" class="btn btn-link"><i class="ai ai-pubmed i-before"></i>PubMed</a>
-                        <a href="https://reporter.nih.gov/search/wLwxNPurzE2RuuqxhvwP9w/projects"
-                                target="_blank" class="btn btn-link"><i class="fa fa-list i-before"></i>NIH Reporter</a>
-                        <a href="https://www.webofscience.com/wos/author/record/K-3037-2015"
-                                target="_blank" class="btn btn-link"><i class="ai ai-clarivate i-before"></i>Web of Science</a>
-                        <a href="https://www.semanticscholar.org/author/Alexandros-Sigaras/2835550"
-                                target="_blank" class="btn btn-link"><i class="ai ai-semantic-scholar i-before"></i>Semantic Scholar</a>
-                        <a href="https://github.com/alexsigaras" target="_blank" class="btn btn-link"><i
-                                class="fab fa-github i-before"></i>Github</a>
+                        <div data-social-links></div>
                     </div>
                     <div class="spread-icons col-md-12 text-center text-md-right">
                         <p class="text-muted mt-3 mb-0">© Alexandros Sigaras<br>
@@ -302,6 +261,7 @@
 
     <!-- JS Core -->
     <script src="assets/js/core.js"></script>
+    <script src="assets/js/social-links.js"></script>
 
     <!-- Retainable/Medium -->
     <!-- <script src="https://www.retainable.io/assets/retainable/rss-embed/retainable-rss-embed.js"></script> -->


### PR DESCRIPTION
## Summary
- drop redundant Font Awesome stylesheet reference
- upgrade remaining Font Awesome CDN link to v6.5.1
- centralize social links in a JSON config and render them programmatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17593259c832892986365e17f87f7