### PR TITLE
Defer scripts to reduce render blocking requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+    <!-- Preconnects -->
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+
     <!-- Favicons -->
     <link rel="shortcut icon" href="assets/img/favicon.png">
     <link rel="apple-touch-icon" href="assets/img/favicon_60x60.png">
@@ -230,36 +234,35 @@
 
     <!-- JS Plugins -->
     <!-- <script src="assets/plugins/jquery/dist/jquery.min.js"></script> -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
         crossorigin="anonymous"></script>
 
-    <script src="assets/plugins/jquery.appear/jquery.appear.js"></script>
+    <script defer src="assets/plugins/jquery.appear/jquery.appear.js"></script>
 
     <!-- <script src="assets/plugins/bootstrap/dist/js/bootstrap.min.js"></script> -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         crossorigin="anonymous"></script>
 
-    <script src="assets/plugins/jquery.scrollto/jquery.scrollTo.min.js"></script>
-    <script src="assets/plugins/jquery.localscroll/jquery.localScroll.min.js"></script>
-    <script src="assets/plugins/imagesloaded/imagesloaded.pkgd.min.js"></script>
-    <script src="assets/plugins/masonry-layout/dist/masonry.pkgd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/4.1.4/imagesloaded.min.js"
+    <script defer src="assets/plugins/jquery.scrollto/jquery.scrollTo.min.js"></script>
+    <script defer src="assets/plugins/jquery.localscroll/jquery.localScroll.min.js"></script>
+    <script defer src="assets/plugins/masonry-layout/dist/masonry.pkgd.min.js"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/4.1.4/imagesloaded.min.js"
         integrity="sha256-7hl8k0pvDP18Fn7+fxHRXxTyUjZRnXcLGBWGoEytZbE=" crossorigin="anonymous"></script>
 
     <!-- <script src="assets/plugins/slick-carousel/slick/slick.min.js"></script> -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js"
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js"
         integrity="sha256-NXRS8qVcmZ3dOv3LziwznUHPegFhPZ1F/4inU7uC8h0=" crossorigin="anonymous"></script>
-    <script src="assets/plugins/waypoints/lib/jquery.waypoints.min.js"></script>
-    <script src="assets/plugins/jquery-validation/dist/jquery.validate.min.js"></script>
-    <script src="assets/plugins/typed.js/dist/typed.min.js"></script>
-    <script src="assets/plugins/easy-pie-chart/dist/jquery.easypiechart.min.js"></script>
+    <script defer src="assets/plugins/waypoints/lib/jquery.waypoints.min.js"></script>
+    <script defer src="assets/plugins/jquery-validation/dist/jquery.validate.min.js"></script>
+    <script defer src="assets/plugins/typed.js/dist/typed.min.js"></script>
+    <script defer src="assets/plugins/easy-pie-chart/dist/jquery.easypiechart.min.js"></script>
 
-    <script src="assets/plugins/snapsvg/dist/snap.svg-min.js"></script>
-    <script src="assets/plugins/isotope-layout/dist/isotope.pkgd.min.js"></script>
+    <script defer src="assets/plugins/snapsvg/dist/snap.svg-min.js"></script>
+    <script defer src="assets/plugins/isotope-layout/dist/isotope.pkgd.min.js"></script>
 
     <!-- JS Core -->
-    <script src="assets/js/core.js"></script>
-    <script src="assets/js/social-links.js"></script>
+    <script defer src="assets/js/core.js"></script>
+    <script defer src="assets/js/social-links.js"></script>
 
     <!-- Retainable/Medium -->
     <!-- <script src="https://www.retainable.io/assets/retainable/rss-embed/retainable-rss-embed.js"></script> -->


### PR DESCRIPTION
## Summary
- preconnect to CDN hosts
- defer script execution and drop duplicate imagesLoaded include to avoid blocking

## Testing
- ❌ `npx --yes htmlhint index.html` (403 Forbidden - GET https://registry.npmjs.org/htmlhint)

------
https://chatgpt.com/codex/tasks/task_e_68c17d4d18ec83288b56cd045d823bab