### PR TITLE
Add meta description for SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
      <meta name="viewport" content="width=device-width, initial-scale=1" />
      <meta name="theme-color" content="#B31B1B" />
+     <meta name="description" content="Personal website of Alex Sigaras, Assistant Professor of Research in Systems and Computational Biomedicine, featuring research, CV, and contact information." />
 
     <!-- Preconnects -->
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>


### PR DESCRIPTION
## Summary
- improve SEO by adding a meta description to the homepage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a46466a08328b06d7b4bff7cd97a