### PR TITLE
Defer CSS to avoid render blocking

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,23 +27,32 @@
 
     <!-- CSS Plugins -->
     <!-- <link rel="stylesheet" href="assets/plugins/bootstrap/dist/css/bootstrap.min.css" /> -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        crossorigin="anonymous">
+    <link rel="preload" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        as="style" onload="this.rel='stylesheet'" crossorigin="anonymous">
+    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        crossorigin="anonymous"></noscript>
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"
         integrity="sha256-+N4/V/SbAFiW1MPBCXnfnP9QSN3+Keu+NlB+0ev/YKQ=" crossorigin="anonymous" /> -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="assets/plugins/animate.css/animate.min.css" />
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" as="style" onload="this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" /></noscript>
+    <link rel="preload" href="assets/plugins/animate.css/animate.min.css" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="assets/plugins/animate.css/animate.min.css" /></noscript>
     <!-- <link rel="stylesheet" href="assets/plugins/slick-carousel/slick/slick.css" /> -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.css"
-        integrity="sha256-3h45mwconzsKjTUULjY+EoEkoRhXcOIU4l5YAw2tSOU=" crossorigin="anonymous" />
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.css"
+        as="style" onload="this.rel='stylesheet'" integrity="sha256-3h45mwconzsKjTUULjY+EoEkoRhXcOIU4l5YAw2tSOU=" crossorigin="anonymous">
+    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.css"
+        integrity="sha256-3h45mwconzsKjTUULjY+EoEkoRhXcOIU4l5YAw2tSOU=" crossorigin="anonymous" /></noscript>
 
     <!-- CSS Icons -->
-     <link rel="stylesheet" href="assets/css/themify-icons.css" />
+     <link rel="preload" href="assets/css/themify-icons.css" as="style" onload="this.rel='stylesheet'">
+     <noscript><link rel="stylesheet" href="assets/css/themify-icons.css" /></noscript>
      <link rel="preload" href="assets/fonts/themify.woff" as="font" type="font/woff" crossorigin />
-     <link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css">
+     <link rel="preload" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" as="style" onload="this.rel='stylesheet'">
+     <noscript><link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" /></noscript>
 
     <!-- CSS Base -->
-    <link id="theme" rel="stylesheet" href="assets/css/themes/theme-cornell-red.min.css" />
+    <link id="theme" rel="preload" href="assets/css/themes/theme-cornell-red.min.css" as="style" onload="this.rel='stylesheet'" />
+    <noscript><link rel="stylesheet" href="assets/css/themes/theme-cornell-red.min.css" /></noscript>
 
 </head>
 


### PR DESCRIPTION
## Summary
- load plugin and icon CSS with `rel="preload"` and `onload` to avoid render-blocking requests
- add noscript fallbacks to ensure styles load without JavaScript
- preload base theme CSS similarly for faster first render

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aa14306883288b460718bb3ad294