### PR TITLE
Add explicit image dimensions to reduce layout shifts

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             data-local-scroll>
 
             <!-- BG Image -->
-             <div class="bg-image-container"><img src="assets/img/photos/Alex_Sigaras_BW.jpg" alt="Portrait of Alex Sigaras" fetchpriority="high" decoding="async"></div>
+             <div class="bg-image-container"><img src="assets/img/photos/Alex_Sigaras_BW.jpg" alt="Portrait of Alex Sigaras" fetchpriority="high" decoding="async" width="2048" height="1591"></div>
 
             <!-- Section Content -->
             <div class="section-content">
@@ -111,7 +111,7 @@
                 <div class="container-slim">
                     <!-- Section Header -->
                     <div class="section-header">
-                     <img src="assets/img/alex/alex-sm.jpg" alt="Alex Sigaras" class="section-header-image" loading="lazy" decoding="async">
+                     <img src="assets/img/alex/alex-sm.jpg" alt="Alex Sigaras" class="section-header-image" loading="lazy" decoding="async" width="129" height="129">
                         <div class="section-header-content"><span class="typing">About Alex Sigaras</span></div>
                     </div>
                     <!-- Resume - About -->
@@ -179,7 +179,7 @@
                     <div class="container-slim">
                         <!-- Section Header -->
                         <div class="section-header">
-                              <img src="assets/img/alex/alex-sm.jpg" alt="Alex Sigaras" class="section-header-image" loading="lazy" decoding="async">
+                              <img src="assets/img/alex/alex-sm.jpg" alt="Alex Sigaras" class="section-header-image" loading="lazy" decoding="async" width="129" height="129">
                             <div class="section-header-content">
                                 <span class="typing">Send me a message</span>
                             </div>


### PR DESCRIPTION
## Summary
- set explicit width and height on hero and profile images to stabilize layout and avoid shifts on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1acace6548328af694b5d6a18e9b5