### PR TITLE
Expose hero image for faster LCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.DS_Store
+node_modules/
+assets/plugins/node_modules/

--- a/assets/css/themes/theme-cornell-red.css
+++ b/assets/css/themes/theme-cornell-red.css
@@ -4563,8 +4563,10 @@ html.locked-scrolling body {
 }
 
 .bg-image-container>img {
-    display: none;
-    position: absolute
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .bg-image-container.bg-image-fixed {

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -84,14 +84,9 @@ Author:         Suelo
                 var $bgImage = $('.bg-image-container',$content);
                 if($bgImage.length) {
                     $bgImage.each(function(){
-                        var src = $(this).children('img').attr('src');
                         var $self = $(this);
 
-                        $self.css('background-image','url('+src+')').children('img').hide();
-
-                        $self.imagesLoaded({
-                            background: true
-                        }, function(instance, image) {
+                        $self.imagesLoaded(function() {
                             $self.addClass('loaded');
                         });
                     });

--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@
      <noscript><link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" /></noscript>
 
     <!-- CSS Base -->
-    <link id="theme" rel="preload" href="assets/css/themes/theme-cornell-red.min.css" as="style" onload="this.rel='stylesheet'" />
-    <noscript><link rel="stylesheet" href="assets/css/themes/theme-cornell-red.min.css" /></noscript>
+    <link id="theme" rel="preload" href="assets/css/themes/theme-cornell-red.css" as="style" onload="this.rel='stylesheet'" />
+    <noscript><link rel="stylesheet" href="assets/css/themes/theme-cornell-red.css" /></noscript>
 
 </head>
 
@@ -261,7 +261,7 @@
     <script defer src="assets/plugins/isotope-layout/dist/isotope.pkgd.min.js"></script>
 
     <!-- JS Core -->
-    <script defer src="assets/js/core.min.js"></script>
+    <script defer src="assets/js/core.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             var links = {


### PR DESCRIPTION
## Summary
- keep hero portrait `<img>` visible and let JavaScript only add a `loaded` class
- show hero image directly with CSS rather than using a background image
- load updated unminified CSS/JS and ignore `node_modules`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bb5527fc8328890414cb481c6658