### PR TITLE
Add canonical and social metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,15 @@
 
     <!-- Title -->
     <title>Alex Sigaras - Assistant Professor of Research in Systems and Computational Biomedicine</title>
+    <link rel="canonical" href="https://alexsigaras.github.io/">
+    <meta property="og:title" content="Alex Sigaras - Assistant Professor of Research in Systems and Computational Biomedicine">
+    <meta property="og:description" content="Personal website of Alex Sigaras, Assistant Professor of Research in Systems and Computational Biomedicine, featuring research, CV, and contact information.">
+    <meta property="og:image" content="https://alexsigaras.github.io/assets/img/photos/Alex_Sigaras_BW.jpg">
+    <meta property="og:url" content="https://alexsigaras.github.io/">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Alex Sigaras - Assistant Professor of Research in Systems and Computational Biomedicine">
+    <meta name="twitter:description" content="Personal website of Alex Sigaras, Assistant Professor of Research in Systems and Computational Biomedicine, featuring research, CV, and contact information.">
+    <meta name="twitter:image" content="https://alexsigaras.github.io/assets/img/photos/Alex_Sigaras_BW.jpg">
     <link rel="preload" as="image" href="assets/img/photos/Alex_Sigaras_BW.jpg" />
 
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" as="style" onload="this.rel='stylesheet'" crossorigin="anonymous">


### PR DESCRIPTION
## Summary
- add canonical link to index page
- include Open Graph and Twitter Card metadata

## Testing
- `npm test` *(fails: could not read package.json)*
- `curl -I https://www.opengraph.xyz/https://alexsigaras.github.io/` *(fails: CONNECT tunnel failed, response 403)*
- `python3 - <<'PY' ...` to verify presence of OG/Twitter meta tags

------
https://chatgpt.com/codex/tasks/task_e_68c1bd96277c832890eb422751a5f370