### PR TITLE
Add SRI hashes for external assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,33 +36,33 @@
     <meta name="twitter:image" content="https://alexsigaras.github.io/assets/img/photos/Alex_Sigaras_BW.jpg">
     <link rel="preload" as="image" href="assets/img/photos/Alex_Sigaras_BW.jpg" />
 
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" as="style" onload="this.rel='stylesheet'" crossorigin="anonymous">
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" crossorigin="anonymous"></noscript>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" as="style" onload="this.rel='stylesheet'" integrity="sha384-9E714GsiIopEvZdiXb5sZVZTxKMPBD3lZrIgFL+f0+VAdU4cbN2KUJdlrQI3fUvo" crossorigin="anonymous">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" integrity="sha384-9E714GsiIopEvZdiXb5sZVZTxKMPBD3lZrIgFL+f0+VAdU4cbN2KUJdlrQI3fUvo" crossorigin="anonymous"></noscript>
 
     <!-- CSS Plugins -->
     <!-- <link rel="stylesheet" href="assets/plugins/bootstrap/dist/css/bootstrap.min.css" /> -->
     <link rel="preload" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        as="style" onload="this.rel='stylesheet'" crossorigin="anonymous">
+        as="style" onload="this.rel='stylesheet'" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        crossorigin="anonymous"></noscript>
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous"></noscript>
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"
         integrity="sha256-+N4/V/SbAFiW1MPBCXnfnP9QSN3+Keu+NlB+0ev/YKQ=" crossorigin="anonymous" /> -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" as="style" onload="this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" /></noscript>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" as="style" onload="this.rel='stylesheet'" integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g" crossorigin="anonymous" referrerpolicy="no-referrer" /></noscript>
     <link rel="preload" href="assets/plugins/animate.css/animate.min.css" as="style" onload="this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="assets/plugins/animate.css/animate.min.css" /></noscript>
     <!-- <link rel="stylesheet" href="assets/plugins/slick-carousel/slick/slick.css" /> -->
     <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.css"
-        as="style" onload="this.rel='stylesheet'" integrity="sha256-3h45mwconzsKjTUULjY+EoEkoRhXcOIU4l5YAw2tSOU=" crossorigin="anonymous">
+        as="style" onload="this.rel='stylesheet'" integrity="sha384-MUdXdzn1OB/0zkr4yGLnCqZ/n9ut5N7Ifes9RP2d5xKsTtcPiuiwthWczWuiqFOn" crossorigin="anonymous">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.css"
-        integrity="sha256-3h45mwconzsKjTUULjY+EoEkoRhXcOIU4l5YAw2tSOU=" crossorigin="anonymous" /></noscript>
+        integrity="sha384-MUdXdzn1OB/0zkr4yGLnCqZ/n9ut5N7Ifes9RP2d5xKsTtcPiuiwthWczWuiqFOn" crossorigin="anonymous" /></noscript>
 
     <!-- CSS Icons -->
      <link rel="preload" href="assets/css/themify-icons.css" as="style" onload="this.rel='stylesheet'">
      <noscript><link rel="stylesheet" href="assets/css/themify-icons.css" /></noscript>
      <link rel="preload" href="assets/fonts/themify.woff" as="font" type="font/woff" crossorigin />
-     <link rel="preload" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" as="style" onload="this.rel='stylesheet'">
-     <noscript><link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" /></noscript>
+     <link rel="preload" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" as="style" onload="this.rel='stylesheet'" integrity="sha384-IAnhEDrYZnLsYcVzowpizdxXTHFovW5/CkZObGfY2QuaCKaQpvLCjj45LGb4Q/yE" crossorigin="anonymous">
+     <noscript><link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" integrity="sha384-IAnhEDrYZnLsYcVzowpizdxXTHFovW5/CkZObGfY2QuaCKaQpvLCjj45LGb4Q/yE" crossorigin="anonymous" /></noscript>
 
     <!-- CSS Base -->
     <link id="theme" rel="preload" href="assets/css/themes/theme-cornell-red.css" as="style" onload="this.rel='stylesheet'" />
@@ -244,23 +244,23 @@
     <!-- JS Plugins -->
     <!-- <script src="assets/plugins/jquery/dist/jquery.min.js"></script> -->
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
-        crossorigin="anonymous"></script>
+        integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
 
     <script defer src="assets/plugins/jquery.appear/jquery.appear.js"></script>
 
     <!-- <script src="assets/plugins/bootstrap/dist/js/bootstrap.min.js"></script> -->
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        crossorigin="anonymous"></script>
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
     <script defer src="assets/plugins/jquery.scrollto/jquery.scrollTo.min.js"></script>
     <script defer src="assets/plugins/jquery.localscroll/jquery.localScroll.min.js"></script>
     <script defer src="assets/plugins/masonry-layout/dist/masonry.pkgd.min.js"></script>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/4.1.4/imagesloaded.min.js"
-        integrity="sha256-7hl8k0pvDP18Fn7+fxHRXxTyUjZRnXcLGBWGoEytZbE=" crossorigin="anonymous"></script>
+        integrity="sha384-YnGSHPPWEUDKMHFPOVmNP7Xyfwx5G0CHet6IoNgiX6CbFZS8gCeIfEgB1MgPwjdI" crossorigin="anonymous"></script>
 
     <!-- <script src="assets/plugins/slick-carousel/slick/slick.min.js"></script> -->
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js"
-        integrity="sha256-NXRS8qVcmZ3dOv3LziwznUHPegFhPZ1F/4inU7uC8h0=" crossorigin="anonymous"></script>
+        integrity="sha384-YGnnOBKslPJVs35GG0TtAZ4uO7BHpHlqJhs0XK3k6cuVb6EBtl+8xcvIIOKV5wB+" crossorigin="anonymous"></script>
     <script defer src="assets/plugins/waypoints/lib/jquery.waypoints.min.js"></script>
     <script defer src="assets/plugins/jquery-validation/dist/jquery.validate.min.js"></script>
     <script defer src="assets/plugins/typed.js/dist/typed.min.js"></script>


### PR DESCRIPTION
## Summary
- Add SHA384 integrity hashes and `crossorigin="anonymous"` to external CSS and JS resources
- Harden loading of fonts, plugins, and libraries by enabling Subresource Integrity

## Testing
- `rg -i 'http://' -n index.html`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &` / `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c1c2420e0c83288b31b0e96a8e3ea7