### PR TITLE
Remove SRI from Google Fonts stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
     <meta name="twitter:image" content="https://alexsigaras.github.io/assets/img/photos/Alex_Sigaras_BW.jpg">
     <link rel="preload" as="image" href="assets/img/photos/Alex_Sigaras_BW.jpg" />
 
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" as="style" onload="this.rel='stylesheet'" integrity="sha384-9E714GsiIopEvZdiXb5sZVZTxKMPBD3lZrIgFL+f0+VAdU4cbN2KUJdlrQI3fUvo" crossorigin="anonymous">
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" integrity="sha384-9E714GsiIopEvZdiXb5sZVZTxKMPBD3lZrIgFL+f0+VAdU4cbN2KUJdlrQI3fUvo" crossorigin="anonymous"></noscript>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"></noscript>
 
     <!-- CSS Plugins -->
     <!-- <link rel="stylesheet" href="assets/plugins/bootstrap/dist/css/bootstrap.min.css" /> -->


### PR DESCRIPTION
## Summary
- drop SRI attributes from Google Fonts links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c95c14648328a46a17743851f64b