### PR TITLE
chore: pin academicons version

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,8 @@
      <link rel="preload" href="assets/css/themify-icons.css" as="style" onload="this.rel='stylesheet'">
      <noscript><link rel="stylesheet" href="assets/css/themify-icons.css" /></noscript>
      <link rel="preload" href="assets/fonts/themify.woff" as="font" type="font/woff" crossorigin />
-     <link rel="preload" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" as="style" onload="this.rel='stylesheet'" integrity="sha384-IAnhEDrYZnLsYcVzowpizdxXTHFovW5/CkZObGfY2QuaCKaQpvLCjj45LGb4Q/yE" crossorigin="anonymous">
-     <noscript><link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css" integrity="sha384-IAnhEDrYZnLsYcVzowpizdxXTHFovW5/CkZObGfY2QuaCKaQpvLCjj45LGb4Q/yE" crossorigin="anonymous" /></noscript>
+     <link rel="preload" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1.9.6/css/academicons.min.css" as="style" onload="this.rel='stylesheet'" integrity="sha384-IAnhEDrYZnLsYcVzowpizdxXTHFovW5/CkZObGfY2QuaCKaQpvLCjj45LGb4Q/yE" crossorigin="anonymous">
+     <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1.9.6/css/academicons.min.css" integrity="sha384-IAnhEDrYZnLsYcVzowpizdxXTHFovW5/CkZObGfY2QuaCKaQpvLCjj45LGb4Q/yE" crossorigin="anonymous" /></noscript>
 
     <!-- CSS Base -->
     <link id="theme" rel="preload" href="assets/css/themes/theme-cornell-red.css" as="style" onload="this.rel='stylesheet'" />


### PR DESCRIPTION
## Summary
- pin Academicons stylesheet to a specific version

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c96310408328a2014e67611c08d4