### PR TITLE
fix: load imagesloaded jQuery plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,8 +255,7 @@
     <script defer src="assets/plugins/jquery.scrollto/jquery.scrollTo.min.js"></script>
     <script defer src="assets/plugins/jquery.localscroll/jquery.localScroll.min.js"></script>
     <script defer src="assets/plugins/masonry-layout/dist/masonry.pkgd.min.js"></script>
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/4.1.4/imagesloaded.min.js"
-        integrity="sha384-YnGSHPPWEUDKMHFPOVmNP7Xyfwx5G0CHet6IoNgiX6CbFZS8gCeIfEgB1MgPwjdI" crossorigin="anonymous"></script>
+    <script defer src="assets/plugins/imagesloaded/imagesloaded.pkgd.min.js"></script>
 
     <!-- <script src="assets/plugins/slick-carousel/slick/slick.min.js"></script> -->
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js"


### PR DESCRIPTION
## Summary
- load packaged `imagesloaded.pkgd.min.js` script so `imagesLoaded` jQuery plugin is available

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1caf094088328b317a85702b5dfb1