### PR TITLE
Fix SRI hash for slick-carousel script

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
 
     <!-- <script src="assets/plugins/slick-carousel/slick/slick.min.js"></script> -->
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js"
-        integrity="sha384-YGnnOBKslPJVs35GG0TtAZ4uO7BHpHlqJhs0XK3k6cuVb6EBtl+8xcvIIOKV5wB+" crossorigin="anonymous"></script>
+        integrity="sha384-OOQxAlvDeToeGLa7+PiUtbtpQyESK8Ej4fNM8foz5VaMpO8TCp1vbi2HIOIzMurt" crossorigin="anonymous"></script>
     <script defer src="assets/plugins/waypoints/lib/jquery.waypoints.min.js"></script>
     <script defer src="assets/plugins/jquery-validation/dist/jquery.validate.min.js"></script>
     <script defer src="assets/plugins/typed.js/dist/typed.min.js"></script>


### PR DESCRIPTION
## Summary
- correct the Subresource Integrity hash for the slick-carousel CDN script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d1227f008328a3d9db234757b220