### PR TITLE
Ensure footer links remain visible on hover

### DIFF
--- a/assets/css/themes/theme-cornell-red.css
+++ b/assets/css/themes/theme-cornell-red.css
@@ -5573,6 +5573,13 @@ html.locked-scrolling body {
     text-decoration: none
 }
 
+.bg-primary .btn-link:hover,
+.bg-primary .btn-link:focus,
+.bg-primary .btn-link:active,
+.bg-primary .btn-link:focus:active {
+    color: #fff;
+}
+
 .btn-toggle[aria-expanded="false"]>span:nth-child(1) {
     display: block
 }

--- a/assets/scss/_elements/_buttons.scss
+++ b/assets/scss/_elements/_buttons.scss
@@ -172,6 +172,14 @@ $k: 1;
     }
 }
 
+.bg-primary {
+    .btn-link {
+        &:hover, &:focus, &:active, &:focus:active {
+            color: #fff;
+        }
+    }
+}
+
 /* Btn Toggle */
 .btn-toggle {
     &[aria-expanded="false"] {


### PR DESCRIPTION
## Summary
- prevent footer links from disappearing on hover by overriding hover color in primary-colored sections
- document rule in SCSS so future builds retain the fix

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/alexsigaras.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d56bb1588328988efb9f6477bde5