### PR TITLE
Fix hero image loading and HTML markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
             data-local-scroll>
 
             <!-- BG Image -->
-             <div class="bg-image-container loaded"><img src="assets/img/photos/Alex_Sigaras_BW.webp" alt="Portrait of Alex Sigaras" fetchpriority="high" decoding="async" width="2048" height="1591"></div>
+             <div class="bg-image-container" style="background-image: url('assets/img/photos/Alex_Sigaras_BW.webp');"><img src="assets/img/photos/Alex_Sigaras_BW.webp" alt="Portrait of Alex Sigaras" fetchpriority="high" decoding="async" width="2048" height="1591"></div>
 
             <!-- Section Content -->
             <div class="section-content">
@@ -129,31 +129,12 @@
                     </div>
                     <!-- Resume - About -->
                     <div class="resume-box" data-local-scroll>
-                        <p class="lead">Alex, is an Assistant Professor of Research in Systems and Computational Biomedicine 
-                            and an Assistant Professor of Research in Computational Biomedicine at Weill Cornell Medicine, 
-                            the Director of AI-XR Lab, and the Director of AI and XR at the Englander Institute for Precision Medicine 
-                            at Weil Cornell Medicine.<br>
-                            <p class="lead">He develops software solutions for the Englander Institute for Precision Medicine 
-                                and Institute for Computational Biomedicine with projects spanning over healthcare system design, 
-                                LIMS and pipeline design for computational genomic analysis. His research interest focus is on leveraging AI 
-                                and Medical Extended Reality technologies in a translational manner benefiting patients but also towards teaching 
-                                the future of medicine in a plethora of medical domains including Precision Medicine, Emergency Medicine, Embryology, 
-                                Otorhinolaryngology, Cardiology, Pathology, Radiology and Medical Education.<br>
-                            <p class="lead">A Fulbright scholar recipient, Alex earned his masters in Computer Science
-                                from Columbia University. While at Columbia, Alex worked as a researcher at Prof.
-                                Allen’s Robotics Lab focusing on medical robotics for surgery and brain computer
-                                interfaces.<br>
-                                <p class="lead">As an undergrad, Alex gave numerous invited talks on his research to
-                                    universities and conferences including the prime minister of Greece and chairman of
-                                    Microsoft Bill Gates. Parallel to his studies, Alex worked at Microsoft’s education
-                                    division helping universities transition to the cloud and as a technical editor in a
-                                    computer magazine.<br>
-                                    <br>
-                                    <a href="cv.pdf" target="_blank" rel="noopener noreferrer" class="btn btn-primary"><i
-                                            class="far fa-file-pdf i-before"></i>Download CV</a>
-                                    <a href="https://www.linkedin.com/in/AlexSigaras" target="_blank" rel="noopener noreferrer"
-                                        class="btn btn-primary"><i class="fab fa-linkedin-in i-before"></i>View
-                                        LinkedIn</a>
+                        <p class="lead">Alex is an Assistant Professor of Research in Systems and Computational Biomedicine and an Assistant Professor of Research in Computational Biomedicine at Weill Cornell Medicine, the Director of AI-XR Lab, and the Director of AI and XR at the Englander Institute for Precision Medicine at Weil Cornell Medicine.</p>
+                        <p class="lead">He develops software solutions for the Englander Institute for Precision Medicine and Institute for Computational Biomedicine with projects spanning over healthcare system design, LIMS and pipeline design for computational genomic analysis. His research interest focuses on leveraging AI and Medical Extended Reality technologies in a translational manner benefiting patients but also towards teaching the future of medicine in a plethora of medical domains including Precision Medicine, Emergency Medicine, Embryology, Otorhinolaryngology, Cardiology, Pathology, Radiology and Medical Education.</p>
+                        <p class="lead">A Fulbright scholar recipient, Alex earned his masters in Computer Science from Columbia University. While at Columbia, Alex worked as a researcher at Prof. Allen’s Robotics Lab focusing on medical robotics for surgery and brain computer interfaces.</p>
+                        <p class="lead">As an undergrad, Alex gave numerous invited talks on his research to universities and conferences including the prime minister of Greece and chairman of Microsoft Bill Gates. Parallel to his studies, Alex worked at Microsoft’s education division helping universities transition to the cloud and as a technical editor in a computer magazine.</p>
+                        <p><a href="cv.pdf" target="_blank" rel="noopener noreferrer" class="btn btn-primary"><i class="far fa-file-pdf i-before"></i>Download CV</a>
+                        <a href="https://www.linkedin.com/in/AlexSigaras" target="_blank" rel="noopener noreferrer" class="btn btn-primary"><i class="fab fa-linkedin-in i-before"></i>View LinkedIn</a></p>
                     </div>
 
                 </div>
@@ -174,7 +155,7 @@
                         <div data-social-links></div>
                     </div>
                     <div class="spread-icons col-md-12 text-center text-md-right">
-                        <p class="text-muted mt-3 mb-0">© <span id="current-year"></span> Alexandros Sigaras<br>
+                        <p class="text-muted mt-3 mb-0">© <span id="current-year"></span> Alexandros Sigaras</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Ensure hero section background image renders by applying background-image style.
- Clean up About section markup and footer tag closure for valid HTML.

## Testing
- `npx --yes htmlhint index.html`
- `python -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/assets/img/photos/Alex_Sigaras_BW.webp`
- `curl -I http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_e_68c1de3622688328b3eb130b66ed83d8